### PR TITLE
Fix: 'MSL' object has no attribute 'sequence_number'

### DIFF
--- a/resources/lib/MSL.py
+++ b/resources/lib/MSL.py
@@ -34,6 +34,7 @@ else:
 
 class MSL(object):
     # Is a handshake already performed and the keys loaded
+    sequence_number = ''
     handshake_performed = False
     last_drm_context = ''
     last_playback_context = ''


### PR DESCRIPTION
Resolves issue 350, which is closed but not resolved.

https://github.com/asciidisco/plugin.video.netflix/issues/350

Fixes the following: "AttributeError: 'MSL' object has no attribute 'sequence_number"

## Types of changes

- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [ X ] Have you followed the guidelines in our Contributing document?
* [ X ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [ X ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ X ] Have you successfully ran tests with your changes locally?
